### PR TITLE
nxos_interfaces model

### DIFF
--- a/models/nxos/interfaces/deleted_example_01.txt
+++ b/models/nxos/interfaces/deleted_example_01.txt
@@ -1,0 +1,12 @@
+
+# Using deleted
+
+- name: Delete given arguments for the interface
+  nxos_interfaces:
+    config:
+      - name: Ethernet1/1
+        description: 'Configured by Ansible'
+      - name: Ethernet1/2
+        description: 'Configured by Ansible Network'
+        mtu: 1800
+    operation: deleted

--- a/models/nxos/interfaces/deleted_example_01.txt
+++ b/models/nxos/interfaces/deleted_example_01.txt
@@ -9,4 +9,4 @@
       - name: Ethernet1/2
         description: 'Configured by Ansible Network'
         mtu: 1800
-    operation: deleted
+    state: deleted

--- a/models/nxos/interfaces/merged_example_01.txt
+++ b/models/nxos/interfaces/merged_example_01.txt
@@ -11,4 +11,4 @@
         description: 'Configured by Ansible Network'
         enable: False
 	mode: layer3
-    operation: merged
+    state: merged

--- a/models/nxos/interfaces/merged_example_01.txt
+++ b/models/nxos/interfaces/merged_example_01.txt
@@ -1,0 +1,14 @@
+
+# Using merged
+
+- name: Configure Eth interfaces
+  nxos_interfaces:
+    config:
+      - name: Ethernet1/1
+        description: 'Configured by Ansible'
+        enable: True
+      - name: Ethernet1/2
+        description: 'Configured by Ansible Network'
+        enable: False
+	mode: layer3
+    operation: merged

--- a/models/nxos/interfaces/nxos_interfaces.yml
+++ b/models/nxos/interfaces/nxos_interfaces.yml
@@ -1,0 +1,99 @@
+generator_version: 1.0
+metadata:
+  vesion: 1.1
+  status:
+  - preview
+  supported_by:
+  - 'Ansible Network'
+  copyright_str: Copyright 2019 Red Hat
+  license: gpl-3.0.txt
+info:
+  network_os: nxos
+  resource: interfaces
+  version_added: 2.9
+  short_description: 'Manages Interfaces attributes of NX-OS Interfaces.'
+  description:
+  - Manages Interfaces attributes of NX-OS Interfaces.
+  authors:
+  - Trishna Guha (@trishnaguha)
+  extends_documentation_fragment: nxos
+  notes:
+    - Tested against <network_os> 7.3.(0)D1(1) on VIRL
+schema:
+  type: object
+  description: The schema used for the argspec and docstring
+  properties:
+    config:
+      type: array
+      description: The provided configuration
+      items:
+        $ref: '#/definitions/config_dict'
+    state:
+      $ref: '#/definitions/state'
+
+definitions:
+  config_dict:
+    description:
+    - The some_dict.
+    type: object
+    properties:
+      name:
+        description:
+        - Full name of interface, i.e. Ethernet1/1, port-channel10.
+        type: str
+        required: true
+      description:
+        description:
+        - Interface description.
+        type: str
+      enable:
+        description:
+        - Administrative State of interface.
+        type: bool
+        default: true
+      speed:
+        description:
+        - Interface link speed. Applicable for ethernet interface only.
+        type: str
+      mode:
+        description:
+        - Manage Layer2 or Layer3 state of the interface.
+          Applicable for Ethernet and portchannel interface only.
+        choices: ['layer2','layer3']
+        type: str
+      mtu:
+        description:
+        - MTU for a specific interface. Must be an even number between 576 and 9216.
+          Applicable for Ethernet interface only.
+        type: str
+      duplex:
+        description:
+        - Interface link status. Applicable for ethernet interface only.
+        type: str
+        default: auto
+        choices: ['full', 'half', 'auto']
+      ip_forward:
+        description:
+        - Enable/Disable ip forward feature on SVIs.
+        type: bool
+      fabric_forwarding_anycast_gateway:
+        description:
+        - Associate SVI with anycast gateway under VLAN configuration mode.
+          Applicable for SVI interface only.
+        type: bool
+
+  state:
+    description:
+    - The state the configuration should be left in
+    type: str
+    enum:
+    - merged
+    - replaced
+    - overridden
+    - deleted
+    default: merged
+examples:
+- merged_example_01.txt
+- replaced_example_01.txt
+- overridden_example_01.txt
+- deleted_example_01.txt

--- a/models/nxos/interfaces/overridden_example_01.txt
+++ b/models/nxos/interfaces/overridden_example_01.txt
@@ -12,4 +12,4 @@
         description: 'Configured by Ansible Network'
         enable: False
 	speed: 1000
-    operation: overridden
+    state: overridden

--- a/models/nxos/interfaces/overridden_example_01.txt
+++ b/models/nxos/interfaces/overridden_example_01.txt
@@ -1,0 +1,15 @@
+
+# Using overridden
+
+- name: Override interfaces
+  nxos_interfaces:
+    config:
+      - name: Ethernet1/1
+        description: 'Configured by Ansible'
+        enable: True
+	mode: layer3
+      - name: Ethernet1/2
+        description: 'Configured by Ansible Network'
+        enable: False
+	speed: 1000
+    operation: overridden

--- a/models/nxos/interfaces/replaced_example_01.txt
+++ b/models/nxos/interfaces/replaced_example_01.txt
@@ -1,0 +1,15 @@
+
+# Using replaced
+
+- name: Configure mentioned interfaces and replace existing config
+  nxos_interfaces:
+    config:
+      - name: Ethernet1/1
+        description: 'Configured by Ansible'
+        enable: True
+	mtu: 2000
+      - name: Ethernet1/2
+        description: 'Configured by Ansible Network'
+        enable: False
+	mode: layer2
+    operation: replaced

--- a/models/nxos/interfaces/replaced_example_01.txt
+++ b/models/nxos/interfaces/replaced_example_01.txt
@@ -12,4 +12,4 @@
         description: 'Configured by Ansible Network'
         enable: False
 	mode: layer2
-    operation: replaced
+    state: replaced

--- a/roles/resource_module/templates/module_directory/network_os/network_os_facts.py.j2
+++ b/roles/resource_module/templates/module_directory/network_os/network_os_facts.py.j2
@@ -40,7 +40,7 @@ options:
         not be collected.
     required: false
     default: 'all'
-    version_added: "2.2"
+    version_added: "2.9"
 """
 
 EXAMPLES = """


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

After build:

**DOCSTRING:**
```
#!/usr/bin/python
# -*- coding: utf-8 -*-
# Copyright 2019 Red Hat
# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

##############################################
################# WARNING ####################
##############################################
###
### This file is auto generated by the resource
###   module builder playbook.
###
### Do not edit this file manually.
###
### Changes to this file will be over written
###   by the resource module builder.
###
### Changes should be made in the model used to
###   generate this file or in the resource module
###   builder template.
###
##############################################
##############################################
##############################################

"""
The module file for nxos_interfaces
"""

from __future__ import absolute_import, division, print_function
from ansible.module_utils.basic import AnsibleModule
from ansible_collections.ansible_network.network.plugins.module_utils. \
     nxos.config.interfaces.interfaces import Interfaces

ANSIBLE_METADATA = {'metadata_version': '1.1',
                    'status': [u'preview'],
                    'supported_by': [u'Ansible Network']}


DOCUMENTATION = """
---
module: nxos_interfaces
version_added: 2.9
short_description: Manages <xxxx> attributes of <network_os> <resource>.
description: [u'Manages <xxxx> attributes of <network_os> <resource>.']
author: [u'Trishna Guha (@trishnaguha)']
options:
  config:
    description: The provided configuration
    suboptions:
      description:
        description:
        - Interface description.
        type: str
      duplex:
        default: auto
        description:
        - Interface link status. Applicable for ethernet interface only.
        type: str
      enable:
        default: true
        description:
        - Administrative State of interface.
        type: bool
      fabric_forwarding_anycast_gateway:
        description:
        - Associate SVI with anycast gateway under VLAN configuration mode. Applicable
          for SVI interface only.
        type: bool
      ip_forward:
        description:
        - Enable/Disable ip forward feature on SVIs.
        type: bool
      mode:
        description:
        - Manage Layer2 or Layer3 state of the interface. Applicable for Ethernet
          and portchannel interface only.
        type: str
      mtu:
        description:
        - MTU for a specific interface. Must be an even number between 576 and 9216.
          Applicable for Ethernet interface only.
        type: str
      name:
        description:
        - Full name of interface, i.e. Ethernet1/1, port-channel10.
        type: str
      speed:
        description:
        - Interface link speed. Applicable for ethernet interface only.
        type: str
  state:
    choices:
    - merged
    - replaced
    - overridden
    - deleted
    default: merged
    description:
    - The state the configuration should be left in
    type: str

"""

EXAMPLES = """
---

# Using merged

- name: Configure Eth interfaces
  nxos_interfaces:
    config:
      - name: Ethernet1/1
        description: 'Configured by Ansible'
        enable: True
      - name: Ethernet1/2
        description: 'Configured by Ansible Network'
        enable: False
	mode: layer3
    operation: merged

# Using replaced

- name: Configure mentioned interfaces and replace existing config
  nxos_interfaces:
    config:
      - name: Ethernet1/1
        description: 'Configured by Ansible'
        enable: True
	mtu: 2000
      - name: Ethernet1/2
        description: 'Configured by Ansible Network'
        enable: False
	mode: layer2
    operation: replaced

# Using overridden

- name: Override interfaces
  nxos_interfaces:
    config:
      - name: Ethernet1/1
        description: 'Configured by Ansible'
        enable: True
	mode: layer3
      - name: Ethernet1/2
        description: 'Configured by Ansible Network'
        enable: False
	speed: 1000
    operation: overridden

# Using deleted

- name: Delete given arguments for the interface
  nxos_interfaces:
    config:
      - name: Ethernet1/1
        description: 'Configured by Ansible'
      - name: Ethernet1/2
        description: 'Configured by Ansible Network'
        mtu: 1800
    operation: deleted
"""
```

**LAYOUT:**
```
plugins/
├── action
├── filter
├── inventory
├── modules
│   ├── __init__.py
│   ├── nxos_facts.py
│   ├── nxos_interfaces.py
│   └── tags
└── module_utils
    ├── __init__.py
    └── nxos
        ├── argspec
        │   ├── facts
        │   │   ├── facts.py
        │   │   └── __init__.py
        │   ├── __init__.py
        │   └── interfaces
        │       ├── __init__.py
        │       └── interfaces.py
        ├── config
        │   ├── base.py
        │   ├── __init__.py
        │   └── interfaces
        │       ├── __init__.py
        │       └── interfaces.py
        ├── facts
        │   ├── base.py
        │   ├── facts.py
        │   ├── __init__.py
        │   └── interfaces
        │       ├── __init__.py
        │       └── interfaces.py
        ├── __init__.py
        └── utils
            ├── __init__.py
            └── utils.py
```