### PR TITLE
[WIP] fix to_argspec filter plugin type casting argspec to str

### DIFF
--- a/roles/resource_module/filter_plugins/to_argspec.py
+++ b/roles/resource_module/filter_plugins/to_argspec.py
@@ -45,7 +45,7 @@ def dive(obj, required=False):
 def to_argspec(value):
     data = jsonref.loads(json.dumps(value))
     result = dive(data['schema'])
-    return str(result['options'])
+    return result['options']
 
 
 class FilterModule(object):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

Type of `argspec` should be dictionary.