### PR TITLE
IOS interface model

### DIFF
--- a/models/ios/interfaces/deleted_example_01.txt
+++ b/models/ios/interfaces/deleted_example_01.txt
@@ -1,0 +1,12 @@
+# Using Deleted
+
+- name: Delete IOS interfaces as in given arguments
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        description: 'Configured by Ansible'
+      - name: GigabitEthernet0/3
+        description: 'Configured by Ansible Network'
+        mtu: 1800
+    operation: deleted
+

--- a/models/ios/interfaces/ios_interface.yaml
+++ b/models/ios/interfaces/ios_interface.yaml
@@ -1,0 +1,84 @@
+generator_version: 1.0
+metadata:
+  version: 1.1
+  status:
+  - preview
+  supported_by:
+  - 'Ansible Network'
+  copyright_str: Copyright 2019 Red Hat
+  license: gpl-3.0.txt
+info:
+  network_os: ios
+  resource: interfaces
+  version_added: 2.9
+  short_description: 'Manage Interface on Cisco IOS network devices.'
+  description:
+  - Manage Interface on Cisco IOS network devices..
+  authors:
+  - Sumit Jaiswal (@justjais)
+  extends_documentation_fragment: ios
+  notes:
+    - Tested against IOS Version 15.6(3)M2 on VIRL
+schema:
+  type: object
+  description: The schema used for the argspec and docstring
+  properties:
+    config:
+      type: array
+      description: The provided configuration
+      items:
+        $ref: '#/definitions/config_dict'
+    state:
+      $ref: '#/definitions/state'
+
+definitions:
+  config_dict:
+    description:
+    - The some_dict.
+    type: object
+    properties:
+      name:
+        description:
+        - Name of interface, i.e. GigabitEthernet0/2, loopback999.
+        type: str
+        required: true
+      description:
+        description:
+        - Description of Interface.
+        type: str
+      enabled:
+        description:
+        - Interface link status.
+        type: bool
+        default: true
+      speed:
+        description:
+        - Interface link speed. Applicable for ethernet interface only.
+        type: str
+      mtu:
+        description:
+        - Maximum size of transmit packet. Must be an number between 64 and 9600.
+          Applicable for Ethernet interface only.
+        type: str
+      duplex:
+        description:
+        - Interface link status. Applicable for ethernet interface only.
+        type: str
+        default: auto
+        choices: ['full', 'half', 'auto']
+
+  state:
+    description:
+    - The state the configuration should be left in
+    type: str
+    enum:
+    - merged
+    - replaced
+    - overridden
+    - deleted
+    default: merged
+examples:
+- merged_example_01.txt
+- replaced_example_01.txt
+- overridden_example_01.txt
+- deleted_example_01.txt

--- a/models/ios/interfaces/ios_interface.yaml
+++ b/models/ios/interfaces/ios_interface.yaml
@@ -13,7 +13,7 @@ info:
   version_added: 2.9
   short_description: 'Manage Interface on Cisco IOS network devices.'
   description:
-  - Manage Interface on Cisco IOS network devices..
+  - Manage Interface on Cisco IOS network devices.
   authors:
   - Sumit Jaiswal (@justjais)
   extends_documentation_fragment: ios

--- a/models/ios/interfaces/merged_example_01.txt
+++ b/models/ios/interfaces/merged_example_01.txt
@@ -1,0 +1,13 @@
+# Using merged
+
+- name: Configure Ethernet interfaces
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        description: 'Configured by Ansible'
+        enabled: True
+      - name: GigabitEthernet0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+	duplex: full
+    operation: merged

--- a/models/ios/interfaces/override_example_01.txt
+++ b/models/ios/interfaces/override_example_01.txt
@@ -1,0 +1,15 @@
+
+# Using overridden
+
+- name: Override interfaces
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        description: 'Configured by Ansible'
+        enabled: True
+        duplex: auto
+      - name: GigabitEthernet0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+        speed: 1000
+    operation: overridden

--- a/models/ios/interfaces/replaced_example_01.txt
+++ b/models/ios/interfaces/replaced_example_01.txt
@@ -1,0 +1,14 @@
+# Using replaced
+
+- name: Configure following interfaces and replace their existing config
+  ios_interfaces:
+    config:
+      - name: GigabitEthernet0/2
+        description: Configured by Ansible
+        enabled: True
+	mtu: 2000
+      - name: GigabitEthernet0/3
+        description: 'Configured by Ansible Network'
+        enabled: False
+	duplex: auto
+    operation: replaced


### PR DESCRIPTION
**Docstring**
```
#!/usr/bin/python
# -*- coding: utf-8 -*-
# Copyright 2019 <company_name>
# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

##############################################
################# WARNING ####################
##############################################
###
### This file is auto generated by the resource
###   module builder playbook.
###
### Do not edit this file manually.
###
### Changes to this file will be over written
###   by the resource module builder.
###
### Changes should be made in the model used to
###   generate this file or in the resource module
###   builder template.
###
##############################################
##############################################
##############################################

"""
The module file for ios_interfaces
"""

from __future__ import absolute_import, division, print_function
from ansible.module_utils.basic import AnsibleModule
from ansible_collections.ansible_network.network.plugins.module_utils. \
     ios.config.interfaces.interfaces import Interfaces

ANSIBLE_METADATA = {'metadata_version': '1.1',
                    'status': [u'preview'],
                    'supported_by': [u'Ansible Network']}


DOCUMENTATION = """
---
module: ios_interfaces
version_added: 2.9
short_description: Manage Interface on Cisco IOS network devices.
description: Manage Interface on Cisco IOS network devices.
author: [u'Sumit Jaiswal (@justjais)']
options:
  config:
    description: The provided configuration
    suboptions:
      name:
        description:
        - Name of interface, i.e. GigabitEthernet0/2, loopback999.
        type: str
        required: true
      description:
        description:
        - Description of Interface.
        type: str
      enabled:
        description:
        - Interface link status.
        type: bool
        default: true
      speed:
        description:
        - Interface link speed. Applicable for ethernet interface only.
        type: str
      mtu:
        description:
        - Maximum size of transmit packet. Must be an number between 64 and 9600.
          Applicable for Ethernet interface only.
        type: str
      duplex:
        description:
        - Interface link status. Applicable for ethernet interface only.
        type: str
        default: auto
        choices: ['full', 'half', 'auto']
  state:
    choices:
    - merged
    - replaced
    - overridden
    - deleted
    default: merged
    description:
    - The state the configuration should be left in
    type: str
"""

EXAMPLES = """
---

# Using merged

- name: Configure Ethernet interfaces
  ios_interfaces:
    config:
      - name: GigabitEthernet0/2
        description: 'Configured by Ansible'
        enabled: True
      - name: GigabitEthernet0/3
        description: 'Configured by Ansible Network'
        enabled: False
        duplex: full
    operation: merged

# Using replaced

- name: Configure following interfaces and replace their existing config
  ios_interfaces:
    config:
      - name: GigabitEthernet0/2
        description: Configured by Ansible
        enabled: True
        mtu: 2000
      - name: GigabitEthernet0/3
        description: 'Configured by Ansible Network'
        enabled: False
        duplex: auto
    operation: replaced

# Using overridden

- name: Override interfaces
  ios_interfaces:
    config:
      - name: GigabitEthernet0/2
        description: 'Configured by Ansible'
        enabled: True
        duplex: auto
      - name: GigabitEthernet0/3
        description: 'Configured by Ansible Network'
        enabled: False
        speed: 1000
    operation: overridden

# Using deleted

- name: Delete IOS interfaces as in given arguments
  ios_interfaces:
    config:
      - name: GigabitEthernet0/2
        description: 'Configured by Ansible'
      - name: GigabitEthernet0/3
        description: 'Configured by Ansible Network'
        mtu: 1800
    operation: deleted

"""
```
**Layout**
```
plugins
   ├── action
   ├── filter
   ├── inventory
   ├── module_utils
   │   ├── __init__.py
   │   ├── ios
   │   │   ├── __init__.py
   │   │   ├── argspec
   │   │   │   ├── __init__.py
   │   │   │   ├── facts
   │   │   │   │   ├── __init__.py
   │   │   │   │   └── facts.py
   │   │   │   └── interfaces
   │   │   │       ├── __init__.py
   │   │   │       └── interfaces.py
   │   │   ├── config
   │   │   │   ├── __init__.py
   │   │   │   ├── base.py
   │   │   │   └── interfaces
   │   │   │       ├── __init__.py
   │   │   │       └── interfaces.py
   │   │   ├── facts
   │   │   │   ├── __init__.py
   │   │   │   ├── base.py
   │   │   │   ├── facts.py
   │   │   │   └── interfaces
   │   │   │       ├── __init__.py
   │   │   │       └── interfaces.py
   │   │   └── utils
   │   │       ├── __init__.py
   │   │       └── utils.py
   │   └── network
   │       ├── __init__.py
   │       └── argspec
   │           ├── __init__.py
   │           └── base.py
   └── modules
       ├── __init__.py
       ├── ios_facts.py
       └── ios_interfaces.py
```