### PR TITLE
Some fixes to RM Builder

### DIFF
--- a/roles/resource_module/filter_plugins/to_argspec.py
+++ b/roles/resource_module/filter_plugins/to_argspec.py
@@ -24,6 +24,8 @@ def dive(obj, required=False):
             result['options'][propkey] = dive(propval, required)
     elif obj['type'] == 'array':
         result['options'] = {}
+        if obj['elements']:
+            result['elements'] = obj['elements']
         if not 'items' in obj:
             raise AnsibleFilterError('missing items key in array')
         if not 'properties' in obj['items']:

--- a/roles/resource_module/templates/module_directory/network_os/network_os_facts.py.j2
+++ b/roles/resource_module/templates/module_directory/network_os/network_os_facts.py.j2
@@ -21,7 +21,7 @@ DOCUMENTATION = """
 ---
 module: {{ network_os }}_facts
 version_added: {{ rm['info']['version_added'] }}
-short_description: {{ rm['info']['short_description'] }}
+short_description: Get facts about {{ network_os }} devices.
 description:
   - Collects facts from network devices running the {{ network_os }} operating
     system. This module places the facts gathered in the fact tree keyed by the

--- a/roles/resource_module/templates/module_directory/network_os/network_os_resource.py.j2
+++ b/roles/resource_module/templates/module_directory/network_os/network_os_resource.py.j2
@@ -56,15 +56,15 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration prior to the model invocation.
   returned: always
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
-  description: The resulting configuration model invocation
+  description: The resulting configuration model invocation.
   returned: when changed
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
-  description: The set of commands pushed to the remote device
+  description: The set of commands pushed to the remote device.
   returned: always
   type: list
   sample: ['command 1', 'command 2', 'command 3']

--- a/roles/resource_module/templates/module_utils/network_os/config/resource/resource.py.j2
+++ b/roles/resource_module/templates/module_utils/network_os/config/resource/resource.py.j2
@@ -105,7 +105,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
         return commands
 
     @staticmethod
-    def _state_replaced(self, **kwargs):
+    def _state_replaced(**kwargs):
         """ The command generator when state is replaced
 
         :rtype: A list
@@ -116,7 +116,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
         return commands
 
     @staticmethod
-    def _state_overridden(self, **kwargs):
+    def _state_overridden(**kwargs):
         """ The command generator when state is overridden
 
         :rtype: A list
@@ -127,7 +127,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
         return commands
 
     @staticmethod
-    def _state_merged(self, **kwargs):
+    def _state_merged(**kwargs):
         """ The command generator when state is merged
 
         :rtype: A list
@@ -138,7 +138,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
         return commands
 
     @staticmethod
-    def _state_deleted(self, **kwargs):
+    def _state_deleted(**kwargs):
         """ The command generator when state is deleted
 
         :rtype: A list

--- a/roles/resource_module/templates/module_utils/network_os/config/resource/resource.py.j2
+++ b/roles/resource_module/templates/module_utils/network_os/config/resource/resource.py.j2
@@ -73,7 +73,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
 
         :rtype: A list
         :returns: the commands necessary to migrate the current configuration
-                  to the deisred configuration
+                  to the desired configuration
         """
         want = self._module.params['config']
         have = self.get_{{ resource }}_facts()
@@ -87,7 +87,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
         :param have: the current configuration as a dictionary
         :rtype: A list
         :returns: the commands necessary to migrate the current configuration
-                  to the deisred configuration
+                  to the desired configuration
         """
         state = self._module.params['state']
         if state == 'overridden':
@@ -110,7 +110,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
 
         :rtype: A list
         :returns: the commands necessary to migrate the current configuration
-                  to the deisred configuration
+                  to the desired configuration
         """
         commands = []
         return commands
@@ -121,7 +121,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
 
         :rtype: A list
         :returns: the commands necessary to migrate the current configuration
-                  to the deisred configuration
+                  to the desired configuration
         """
         commands = []
         return commands

--- a/roles/resource_module/templates/module_utils/network_os/config/resource/resource.py.j2
+++ b/roles/resource_module/templates/module_utils/network_os/config/resource/resource.py.j2
@@ -45,7 +45,7 @@ class {{ resource|capitalize }}(ConfigBase, {{ resource|capitalize }}Args):
         """ Execute the module
 
         :rtype: A dictionary
-        :returns: The result from moduel execution
+        :returns: The result from module execution
         """
         result = {'changed': False}
         commands = list()

--- a/roles/resource_module/templates/module_utils/network_os/facts/base.py.j2
+++ b/roles/resource_module/templates/module_utils/network_os/facts/base.py.j2
@@ -98,7 +98,7 @@ class FactsBase(object): #pylint: disable=R0205
 
         :param cfg_dict: A dictionary parsed in the facts system
         :rtype: A dictionary
-        :returns: A dictionary by elimating keys that have null values
+        :returns: A dictionary by eliminating keys that have null values
         """
         final_cfg = {}
         if not cfg_dict:


### PR DESCRIPTION
- The `short_description` key for `{{ network_os }}_facts` was using `rm['info']['short_description']`.
- This patch adds the correct value.
- Some typo fixes
- Remove `self` from static methods
- Add `elements` support in `to_argspec`