### PR TITLE
README update, and fixes necessary for stub module and facts to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ ansible-playbook -e parent=~/github/rm_example/roles/my_role \
 
 **Using the collection layout**
 
-Note: As of 3/26/2019, the following PR needs to be used:
 ```
 git clone git@github.com:ansible/ansible.git
 cd ansible

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ ln -s ~/github/rm_example ~/.ansible/collections/ansible_collections/cidrblock/m
        var: result
    - cidrblock.my_collection.myos_facts:
    - debug:
-       var: net_configuration
+       var: ansible_network_resources
 
 ```
 
@@ -202,7 +202,7 @@ ln -s ~/github/rm_example ~/.ansible/collections/ansible_collections/cidrblock/m
       var: result
   - myos_facts:
   - debug:
-      var: net_configuration
+      var: ansible_network_resources
 ```
 
 ### Resource Module Structure/Workflow

--- a/models/myos/interfaces/myos_interfaces.yml
+++ b/models/myos/interfaces/myos_interfaces.yml
@@ -53,16 +53,16 @@ DOCUMENTATION: |
               description:
               - The property_01
               type: str
-        state:
-          description:
-          - The state the configuration should be left in
-          type: str
-          choices:
-          - merged
-          - replaced
-          - overridden
-          - deleted
-          default: merged
+    state:
+      description:
+      - The state the configuration should be left in
+      type: str
+      choices:
+      - merged
+      - replaced
+      - overridden
+      - deleted
+      default: merged
 EXAMPLES:
   - deleted_example_01.txt
   - merged_example_01.txt

--- a/roles/resource_module/templates/module_directory/network_os/network_os_facts.py.j2
+++ b/roles/resource_module/templates/module_directory/network_os/network_os_facts.py.j2
@@ -96,12 +96,9 @@ def main():
     gather_subset = module.params['gather_subset']
     gather_network_resources = module.params['gather_network_resources']
     result = Facts().get_facts(module, connection, gather_subset, gather_network_resources)
-    
-    try:
-        ansible_facts, warning = result
-        warnings.extend(warning)
-    except (TypeError, KeyError):
-        ansible_facts = result
+
+    ansible_facts, additional_warnings = result
+    warnings.extend(additional_warnings)
 
     module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 

--- a/roles/resource_module/templates/module_utils/network_os/facts/facts.py.j2
+++ b/roles/resource_module/templates/module_utils/network_os/facts/facts.py.j2
@@ -110,10 +110,8 @@ class Facts(FactsArgs, FactsBase): #pylint: disable=R0903
                     key = 'ansible_net_%s' % key
                     self.ansible_facts[key] = value
 
-        if warnings:
-            return self.ansible_facts, warnings
-        else:
-            return self.ansible_facts
+        return self.ansible_facts, warnings
+
 
 
     @staticmethod


### PR DESCRIPTION
The model was incorrect, state was a child of config, the module would error out if state was not provided.  Also- The Facts were returning a dict when no additional warnings were created which was causing the following error
```
line 103, in main\nValueError: too many values to unpack\n"
```
So, this will always return both the facts, and warnings from Facts, any additional warnings will be appended the min warning.