### PR TITLE
populate_facts delete resource key if already exists in ansible_facts

### DIFF
--- a/roles/scaffold_rm_facts/templates/module_utils/network_os/facts/resource/resource.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_utils/network_os/facts/resource/resource.py.j2
@@ -58,6 +58,8 @@ class {{ resource|capitalize }}Facts(FactsBase):
                 obj = self.render_config(self.generated_spec, resource)
                 if obj:
                     objs.append(obj)
+
+        self.ansible_facts['ansible_network_resources'].pop('{{ resource }}', None)
         facts = {}
         if objs:
             facts['{{ resource }}'] = objs


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>