### PR TITLE
Add netconf support

### DIFF
--- a/roles/scaffold_rm_facts/templates/module_utils/network_os/config/resource/resource.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_utils/network_os/config/resource/resource.py.j2
@@ -13,6 +13,11 @@ created
 from ansible.module_utils.network.common.cfg.base import ConfigBase
 from ansible.module_utils.network.common.utils import to_list
 from {{ import_path }}.{{ network_os }}.facts.facts import Facts
+{% if transport.netconf %}
+from ansible.module_utils.network.netconf.netconf import locked_config
+from ansible.module_utils.network.common.netconf import (build_root_xml_node,
+                                                         build_child_xml_node)
+{% endif %}
 
 
 class {{ resource|capitalize }}(ConfigBase):
@@ -51,8 +56,29 @@ class {{ resource|capitalize }}(ConfigBase):
         :returns: The result from module execution
         """
         result = {'changed': False}
-        commands = list()
+{% if transport.netconf %}
+        existing_{{ resource }}_facts = self.get_{{ resource }}_facts()
+        config_xmls = self.set_config(existing_{{ resource }}_facts)
+
+        with locked_config(self._module):
+            for config_xml in to_list(config_xmls):
+                diff = self._module._connectionload_config(self._module, config_xml, [])
+
+            commit = not self._module.check_mode
+            if diff:
+                if commit:
+                    self._module._connection.commit_configuration(self._module)
+                else:
+                    self._module._connection.discard_changes(self._module)
+                result['changed'] = True
+
+                if self._module._diff:
+                    result['diff'] = {'prepared': diff}
+
+        result['xml'] = config_xmls
+{% else %}
         warnings = list()
+        commands = list()
 
         existing_{{ resource }}_facts = self.get_{{ resource }}_facts()
         commands.extend(self.set_config(existing_{{ resource }}_facts))
@@ -62,6 +88,7 @@ class {{ resource|capitalize }}(ConfigBase):
             result['changed'] = True
         result['commands'] = commands
 
+{% endif %}
         changed_{{ resource }}_facts = self.get_{{ resource }}_facts()
 
         result['before'] = existing_{{ resource }}_facts
@@ -93,6 +120,23 @@ class {{ resource|capitalize }}(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
+{% if transport.netconf %}
+        root = build_root_xml_node('{{ resource }}')
+        state = self._module.params['state']
+        if state == 'overridden':
+            config_xmls = self._state_overridden(want, have)
+        elif state == 'deleted':
+            config_xmls = self._state_deleted(want, have)
+        elif state == 'merged':
+            config_xmls = self._state_merged(want, have)
+        elif state == 'replaced':
+            config_xmls = self._state_replaced(want, have)
+
+        for xml in config_xmls:
+            root.append(xml)
+
+        return self._module._connection.tostring(root)
+{% else %}
         state = self._module.params['state']
         if state == 'overridden':
             kwargs = {}
@@ -107,7 +151,47 @@ class {{ resource|capitalize }}(ConfigBase):
             kwargs = {}
             commands = self._state_replaced(**kwargs)
         return commands
+{% endif %}
+{% if transport.netconf %}
+    def _state_replaced(self, want, have):
+        """ The command generator when state is replaced
 
+        :rtype: A list
+        :returns: the xml necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        intf_xml = []
+        return intf_xml
+
+    def _state_overridden(self, want, have):
+        """ The command generator when state is overridden
+
+        :rtype: A list
+        :returns: the xml necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        intf_xml = []
+        return intf_xml
+    def _state_deleted(self, want, have):
+        """ The command generator when state is deleted
+
+        :rtype: A list
+        :returns: the xml necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        intf_xml = []
+        return intf_xml
+
+    def _state_merged(self, want, have):
+        """ The command generator when state is merged
+
+        :rtype: A list
+        :returns: the xml necessary to migrate the current configuration
+                  to the desired configuration
+        """
+        intf_xml = []
+        return intf_xml
+{% else %}
     @staticmethod
     def _state_replaced(**kwargs):
         """ The command generator when state is replaced
@@ -151,3 +235,4 @@ class {{ resource|capitalize }}(ConfigBase):
         """
         commands = []
         return commands
+{% endif %}

--- a/roles/scaffold_rm_facts/templates/module_utils/network_os/facts/resource/resource.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_utils/network_os/facts/resource/resource.py.j2
@@ -9,11 +9,24 @@ It is in this file the configuration is collected from the device
 for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
+{% if not transport.netconf %}
 import re
+{% endif %}
 from copy import deepcopy
 
+{% if transport.netconf %}
+from ansible.module_utils._text import to_bytes
+{% endif %}
 from ansible.module_utils.network.common import utils
 from {{ import_path }}.{{ network_os }}.argspec.{{ resource }}.{{ resource }} import {{ resource|capitalize }}Args
+{% if transport.netconf %}
+from ansible.module.utils.six import string_types
+try:
+    from lxml import etree
+    HAS_LXML = True
+except ImportError:
+    HAS_LXML = False
+{% endif %}
 
 
 class {{ resource|capitalize }}Facts(object):
@@ -42,6 +55,25 @@ class {{ resource|capitalize }}Facts(object):
         :rtype: dictionary
         :returns: facts
         """
+{% if transport.netconf %}
+        if not HAS_LXML:
+            self._module.fail_json(msg='lxml is not installed.')
+
+        if not data:
+            config_filter = """
+                <configuration>
+                  <resource>
+                  </resource>
+                </configuration>
+                """
+            data = connection.get_configuration(filter=config_filter)
+
+        if isinstance(data, string_types):
+            data = etree.fromstring(to_bytes(data,
+                                             errors='surrogate_then_replace'))
+
+        resources = data.xpath('configuration/resources/resource')
+{% else %}
         if connection:  # just for linting purposes, remove
             pass
 
@@ -64,6 +96,7 @@ class {{ resource|capitalize }}Facts(object):
         resources = [p.strip() for p in re.findall(find_pattern,
                                                    data,
                                                    re.DOTALL)]
+{% endif %}
 
         objs = []
         for resource in resources:
@@ -72,11 +105,21 @@ class {{ resource|capitalize }}Facts(object):
                 if obj:
                     objs.append(obj)
 
+{% if transport.netconf %}
+        facts = {}
+        if objs:
+            facts['resource'] = []
+            params = utils.validate_config(self.argument_spec,
+                                           {'config': objs})
+            for cfg in params['config']:
+                facts['resource'].append(utils.remove_empties(cfg))
+{% else %}
         ansible_facts['ansible_network_resources'].pop('{{ resource }}', None)
         facts = {}
         if objs:
             params = utils.validate_config(self.argument_spec, {'config': objs})
             facts['{{ resource }}'] = params['config']
+{% endif %}
 
         ansible_facts['ansible_network_resources'].update(facts)
         return ansible_facts
@@ -92,7 +135,10 @@ class {{ resource|capitalize }}Facts(object):
         :returns: The generated config
         """
         config = deepcopy(spec)
-
+{% if transport.netconf %}
+        config['name'] = utils.get_xml_conf_arg(conf, 'name')
+        config['some_value'] = utils.get_xml_conf_arg(conf, 'some_value')
+{% else %}
         config['name'] = utils.parse_conf_arg(conf, 'resource')
         config['some_string'] = utils.parse_conf_arg(conf, 'a_string')
 
@@ -113,5 +159,5 @@ class {{ resource|capitalize }}Facts(object):
             config['some_int'] = int(utils.parse_conf_arg(conf, 'an_int'))
         except TypeError:
             config['some_int'] = None
-
+{% endif %}
         return utils.remove_empties(config)


### PR DESCRIPTION
This commit adds support for bootstrapping netconf modules. Although
originally meant to be used by junos, it should be portable to any
another network os supporting netconf protocol.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>