### PR TITLE
Fix error due to netconf var not being defined

### DIFF
--- a/roles/scaffold_rm_facts/templates/module_utils/network_os/config/resource/resource.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_utils/network_os/config/resource/resource.py.j2
@@ -13,7 +13,7 @@ created
 from ansible.module_utils.network.common.cfg.base import ConfigBase
 from ansible.module_utils.network.common.utils import to_list
 from {{ import_path }}.{{ network_os }}.facts.facts import Facts
-{% if transport.netconf %}
+{% if transport == 'netconf' %}
 from ansible.module_utils.network.netconf.netconf import locked_config
 from ansible.module_utils.network.common.netconf import (build_root_xml_node,
                                                          build_child_xml_node)
@@ -56,7 +56,7 @@ class {{ resource|capitalize }}(ConfigBase):
         :returns: The result from module execution
         """
         result = {'changed': False}
-{% if transport.netconf %}
+{% if transport == 'netconf' %}
         existing_{{ resource }}_facts = self.get_{{ resource }}_facts()
         config_xmls = self.set_config(existing_{{ resource }}_facts)
 
@@ -120,7 +120,7 @@ class {{ resource|capitalize }}(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-{% if transport.netconf %}
+{% if transport == 'netconf' %}
         root = build_root_xml_node('{{ resource }}')
         state = self._module.params['state']
         if state == 'overridden':
@@ -152,7 +152,7 @@ class {{ resource|capitalize }}(ConfigBase):
             commands = self._state_replaced(**kwargs)
         return commands
 {% endif %}
-{% if transport.netconf %}
+{% if transport == 'netconf' %}
     def _state_replaced(self, want, have):
         """ The command generator when state is replaced
 

--- a/roles/scaffold_rm_facts/templates/module_utils/network_os/facts/resource/resource.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_utils/network_os/facts/resource/resource.py.j2
@@ -9,17 +9,17 @@ It is in this file the configuration is collected from the device
 for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
-{% if not transport.netconf %}
+{% if not transport=='netconf' %}
 import re
 {% endif %}
 from copy import deepcopy
 
-{% if transport.netconf %}
+{% if transport=='netconf' %}
 from ansible.module_utils._text import to_bytes
 {% endif %}
 from ansible.module_utils.network.common import utils
 from {{ import_path }}.{{ network_os }}.argspec.{{ resource }}.{{ resource }} import {{ resource|capitalize }}Args
-{% if transport.netconf %}
+{% if transport=='netconf' %}
 from ansible.module.utils.six import string_types
 try:
     from lxml import etree
@@ -55,7 +55,7 @@ class {{ resource|capitalize }}Facts(object):
         :rtype: dictionary
         :returns: facts
         """
-{% if transport.netconf %}
+{% if transport=='netconf' %}
         if not HAS_LXML:
             self._module.fail_json(msg='lxml is not installed.')
 
@@ -105,7 +105,7 @@ class {{ resource|capitalize }}Facts(object):
                 if obj:
                     objs.append(obj)
 
-{% if transport.netconf %}
+{% if transport=='netconf' %}
         facts = {}
         if objs:
             facts['resource'] = []
@@ -135,7 +135,7 @@ class {{ resource|capitalize }}Facts(object):
         :returns: The generated config
         """
         config = deepcopy(spec)
-{% if transport.netconf %}
+{% if transport=='netconf' %}
         config['name'] = utils.get_xml_conf_arg(conf, 'name')
         config['some_value'] = utils.get_xml_conf_arg(conf, 'some_value')
 {% else %}

--- a/roles/scaffold_rm_facts/vars/main.yml
+++ b/roles/scaffold_rm_facts/vars/main.yml
@@ -2,6 +2,9 @@
 network_os: "{{ rm['NETWORK_OS'] }}"
 resource: "{{ rm['RESOURCE'] }}"
 
+# set transport to network_cli unless overridden in cli
+transport: network_cli
+
 # set the directory for modules based on the structure
 module_directories:
   role: library


### PR DESCRIPTION
This commit defines the netconf var in order for rmb to be able to
properly create resource models with or without netconf.