### PR TITLE
Fix netconf six import

### DIFF
--- a/roles/scaffold_rm_facts/templates/module_utils/network_os/facts/resource/resource.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_utils/network_os/facts/resource/resource.py.j2
@@ -20,7 +20,7 @@ from ansible.module_utils._text import to_bytes
 from ansible.module_utils.network.common import utils
 from {{ import_path }}.{{ network_os }}.argspec.{{ resource }}.{{ resource }} import {{ resource|capitalize }}Args
 {% if transport=='netconf' %}
-from ansible.module.utils.six import string_types
+from ansible.module_utils.six import string_types
 try:
     from lxml import etree
     HAS_LXML = True


### PR DESCRIPTION
When using netconf transport, there was a wrong import for six, which
led to quite a few issues afterwards.