### PR TITLE
Update jinja templates

### DIFF
--- a/roles/scaffold_rm_facts/templates/module_directory/network_os/network_os_facts.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_directory/network_os/network_os_facts.py.j2
@@ -11,15 +11,16 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '{{rm_ansible_metadata['metadata_version']}}',
-                    'status': {{rm_ansible_metadata['status']}},
-                    'supported_by': '{{rm_ansible_metadata['supported_by']}}'}
+ANSIBLE_METADATA = {
+    'metadata_version': '{{rm_ansible_metadata['metadata_version']}}',
+    'status': {{rm_ansible_metadata['status']}},
+    'supported_by': '{{rm_ansible_metadata['supported_by']}}'}
 
 
 DOCUMENTATION = """
 ---
 module: {{ network_os }}_facts
-version_added: {{ rm_docmentation['version_added'] }}
+version_added: '{{ rm_docmentation['version_added'] }}'
 short_description: Get facts about {{ network_os }} devices.
 description:
   - Collects facts from network devices running the {{ network_os }} operating

--- a/roles/scaffold_rm_facts/templates/module_utils/network_os/argspec/resource/resource.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_utils/network_os/argspec/resource/resource.py.j2
@@ -25,6 +25,8 @@
 """
 The arg spec for the {{ network_os }}_{{ resource }} module
 """
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 
 class {{ resource|capitalize }}Args(object):  # pylint: disable=R0903

--- a/roles/scaffold_rm_facts/templates/module_utils/network_os/config/resource/resource.py.j2
+++ b/roles/scaffold_rm_facts/templates/module_utils/network_os/config/resource/resource.py.j2
@@ -14,7 +14,11 @@ from ansible.module_utils.network.common.cfg.base import ConfigBase
 from ansible.module_utils.network.common.utils import to_list
 from {{ import_path }}.{{ network_os }}.facts.facts import Facts
 {% if transport == 'netconf' %}
-from ansible.module_utils.network.netconf.netconf import locked_config
+from ansible.module_utils.network.junos.junos import (locked_config,
+                                                      load_config,
+                                                      commit_configuration,
+                                                      discard_changes,
+                                                      tostring)
 from ansible.module_utils.network.common.netconf import (build_root_xml_node,
                                                          build_child_xml_node)
 {% endif %}
@@ -62,14 +66,14 @@ class {{ resource|capitalize }}(ConfigBase):
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):
-                diff = self._module._connectionload_config(self._module, config_xml, [])
+                diff = load_config(self._module, config_xml, [])
 
             commit = not self._module.check_mode
             if diff:
                 if commit:
-                    self._module._connection.commit_configuration(self._module)
+                    commit_configuration(self._module)
                 else:
-                    self._module._connection.discard_changes(self._module)
+                    discard_changes(self._module)
                 result['changed'] = True
 
                 if self._module._diff:
@@ -135,7 +139,7 @@ class {{ resource|capitalize }}(ConfigBase):
         for xml in config_xmls:
             root.append(xml)
 
-        return self._module._connection.tostring(root)
+        return tostring(root)
 {% else %}
         state = self._module.params['state']
         if state == 'overridden':


### PR DESCRIPTION
This commit makes some changes on the jinja template so they:
- contain the needed boilerplate on ansible/ansible
- use junos imports by default on netconf
- quote ansible version in module in order to avoid bad parsing (i.e
  2.10->'2.10')

Signed-off-by: Daniel Mellado <dmellado@redhat.com>