### PR TITLE
Ignore deprecation warnings

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,4 @@
 retry_files_enabled = False
 stdout_callback = debug
 jinja2_native = True
+deprecation_warnings = False


### PR DESCRIPTION
This is probably the result of a bigger underlying problem, but
setting deprecation_warnings = False fixed the warning below

TASK [scaffold_rm_facts : Create the file, if it doesnt exist already or override is set] ****************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: """
fatal: [localhost]: FAILED! => {
    "changed": false
}

MSG:

AnsibleError: Failed to validate the model with error: Error while parsing module: b'[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the \ncontroller starting with Ansible 2.12. Current version: 3.6.8 (default, Mar 18 \n2021, 08:58:41) [GCC 8.4.1 20200928 (Red Hat 8.4.1-1)]. This feature will be \nremoved from ansible-core in version 2.12. Deprecation warnings can be disabled\n by setting deprecation_warnings=False in ansible.cfg.\n'