### PR TITLE
Replace include with include_tasks

### DIFF
--- a/rmb_tests/roles/tests/tasks/main.yml
+++ b/rmb_tests/roles/tests/tasks/main.yml
@@ -1,4 +1,4 @@
-- include: "{{ item }}"
+- include_tasks: "{{ item }}"
   loop:
   - facts.yml
   - argspec.yml

--- a/roles/scaffold_rm_facts/tasks/main.yml
+++ b/roles/scaffold_rm_facts/tasks/main.yml
@@ -12,7 +12,7 @@
   with_items: "{{ resource_module_directories }}"
 
 - name: Template each of the files
-  include: template.yml
+  include_tasks: template.yml
   with_items: "{{ resource_module_templates }}"
   loop_control:
     loop_var: template


### PR DESCRIPTION
This PR replaces `include` with `include_tasks` because `ansible.builtin.include` is removed on Ansible 2.16.